### PR TITLE
VCenter 6 log location update

### DIFF
--- a/nxlog/nxlogvCenter6.conf
+++ b/nxlog/nxlogvCenter6.conf
@@ -1,0 +1,57 @@
+## This is a sample configuration file. See the nxlog reference manual about the
+## configuration options. It should be installed locally and is also available
+## online at http://nxlog.org/nxlog-docs/en/nxlog-reference-manual.html
+
+## Please set the ROOT to the folder your nxlog was installed into,
+## otherwise it will not start.
+
+#define ROOT C:\Program Files\nxlog
+define ROOT C:\Program Files (x86)\nxlog
+
+Moduledir %ROOT%\modules
+CacheDir %ROOT%\data
+Pidfile %ROOT%\data\nxlog.pid
+SpoolDir %ROOT%\data
+LogFile %ROOT%\data\nxlog.log
+
+<Extension json>
+    Module      xm_json
+</Extension>
+
+<Input in_eventlog>
+   Module im_msvistalog
+</Input>
+
+<Input in_vc_logs>
+    Module	im_file
+##  ncomment below if using vCenter 5.5 or earlier    
+##    File	'C:\\ProgramData\\VMware\\VMware VirtualCenter\\Logs\\vpxd*.log'
+## uncomment below if using vCenter 6
+##   File	'C:\ProgramData\VMware\vCenterServer\Logs\\\vpxd*.log'
+    SavePos	TRUE
+	Exec	$message = $raw_event;
+	Exec	$hostname = hostname_fqdn();
+	Exec	$filename = file_name();
+</Input>
+
+<Output out_vc_logs>
+    Module      om_udp
+    Host        127.0.0.1
+    Port        1514
+	Exec		to_json();
+</Output>
+
+<Output out_eventlog>
+    Module      om_udp
+    Host        127.0.0.1
+    Port        1515
+	Exec		to_json();
+</Output>
+
+<Route vc_logs>
+    Path        in_vc_logs => out_vc_logs
+</Route>
+
+<Route eventlog>
+    Path        in_eventlog => out_eventlog
+</Route>


### PR DESCRIPTION
VMware changed the location of the vCenter log files to \VMware\vCenterServer\logs
I modified the <Input in_vc_logs> section so that users can uncomment the appropriate log directory depending on what they are running